### PR TITLE
Prevent an error when calling prettify(conjugate(''))

### DIFF
--- a/koparadigm/koparadigm.py
+++ b/koparadigm/koparadigm.py
@@ -173,6 +173,7 @@ class Paradigm(object):
             return paradigms
         else:
             print(f"{verb} is NOT found.")
+            return []
 
 
 def prettify(paradigms):


### PR DESCRIPTION
Changes conjugate() to return an empty list instead of None when the verb is not found, to prevent a TypeError being raised when prettify is called.

e.g. The following no longer raises an error.
```py
from koparadigm import Paradigm, prettify
p = Paradigm()
prettify(p.conjugate(""))
```